### PR TITLE
Fix code scanning alert no. 320: Log entries created from user input

### DIFF
--- a/DotnetPlayground.Web/Repositories/HashesRepository.cs
+++ b/DotnetPlayground.Web/Repositories/HashesRepository.cs
@@ -661,7 +661,7 @@ LIMIT @limit OFFSET @offset
 				using (var cmd = new NpgsqlCommand(sql, conn))
 				{
 					cmd.CommandText = sql;
-					_logger.LogInformation("sql => {sql}", sql);
+					_logger.LogInformation("sql => {sql}", sql.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
 					cmd.CommandTimeout = 240;
 					DbParameter parameter;
 


### PR DESCRIPTION
Fixes [https://github.com/ChaosEngine/Dotnet-Playground/security/code-scanning/320](https://github.com/ChaosEngine/Dotnet-Playground/security/code-scanning/320)

To fix the problem, we need to sanitize the `sql` variable before logging it. Since the log entries are plain text, we should remove any newline characters from the `sql` string to prevent log forgery. This can be done using the `Replace` method to remove newline characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
